### PR TITLE
Throw error object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.4.2
+* Throw Error object instead of just the error message
+
 ### 0.4.1
 * Pass schemas along in subquery type
 * Add missing hasValue functions for subquery and savedSearch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,12 +73,10 @@ let runTypeFunction = config => async (name, item, search) => {
       ? fn(item, search, schema, config)
       : fn(item, schema, config))
   } catch (error) {
-    throw new Error(
-      throw {
-        message: `Failed running search for ${item.type} (${item.key}) at ${name}: ${_.getOr(error, 'message', error)}`,
-        error
-      }
-    )
+    throw {
+      message: `Failed running search for ${item.type} (${item.key}) at ${name}: ${_.getOr(error, 'message', error)}`,
+      error
+    }
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,7 +75,7 @@ let runTypeFunction = config => async (name, item, search) => {
   } catch (error) {
     throw {
       message: `Failed running search for ${item.type} (${item.key}) at ${name}: ${_.getOr(error, 'message', error)}`,
-      error
+      F.extendOn(error, { item })
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,9 +72,12 @@ let runTypeFunction = config => async (name, item, search) => {
     return await (search
       ? fn(item, search, schema, config)
       : fn(item, schema, config))
-  } catch (e) {
+  } catch (error) {
     throw new Error(
-      `Failed running search for ${item.type} (${item.key}) at ${name}: ${e}`
+      throw {
+        message: `Failed running search for ${item.type} (${item.key}) at ${name}: ${_.getOr(error, 'message', error)}`,
+        error
+      }
     )
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,8 +72,10 @@ let runTypeFunction = config => async (name, item, search) => {
       : fn(item, schema, config))
   } catch (error) {
     throw {
-      message: `Failed running search for ${item.type} (${item.key}) at ${name}: ${_.getOr(error, 'message', error)}`,
-      error: F.extendOn(error, { node: item })
+      message: `Failed running search for ${item.type} (${
+        item.key
+      }) at ${name}: ${_.getOr(error, 'message', error)}`,
+      error: F.extendOn(error, { node: item }),
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,9 @@ let getProvider = _.curry(
     ] ||
     F.throws(
       new Error(
-        `No Provider found ${item.schema} and was not overridden for ${item.key}`
+        `No Provider found ${item.schema} and was not overridden for ${
+          item.key
+        }`
       )
     )
 )
@@ -73,7 +75,7 @@ let runTypeFunction = config => async (name, item, search) => {
   } catch (error) {
     throw {
       message: `Failed running search for ${item.type} (${item.key}) at ${name}: ${_.getOr(error, 'message', error)}`,
-      error: F.extendOn(error, { node: item })
+      error, node: item
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,9 +23,7 @@ let getProvider = _.curry(
     ] ||
     F.throws(
       new Error(
-        `No Provider found ${item.schema} and was not overridden for ${
-          item.key
-        }`
+        `No Provider found ${item.schema} and was not overridden for ${item.key}`
       )
     )
 )
@@ -74,9 +72,11 @@ let runTypeFunction = config => async (name, item, search) => {
       : fn(item, schema, config))
   } catch (error) {
     throw {
-      message: `Failed running search for ${item.type} (${item.key}) at ${name}: ${_.getOr(error, 'message', error)}`,
+      message: `Failed running search for ${item.type} (${
+        item.key
+      }) at ${name}: ${_.getOr(error, 'message', error)}`,
       error,
-      node: item
+      node: item,
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,7 +73,7 @@ let runTypeFunction = config => async (name, item, search) => {
   } catch (error) {
     throw {
       message: `Failed running search for ${item.type} (${item.key}) at ${name}: ${_.getOr(error, 'message', error)}`,
-      F.extendOn(error, { item })
+      F.extendOn(error, { node: item })
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,9 +23,7 @@ let getProvider = _.curry(
     ] ||
     F.throws(
       new Error(
-        `No Provider found ${item.schema} and was not overridden for ${
-          item.key
-        }`
+        `No Provider found ${item.schema} and was not overridden for ${item.key}`
       )
     )
 )
@@ -74,8 +72,10 @@ let runTypeFunction = config => async (name, item, search) => {
       : fn(item, schema, config))
   } catch (error) {
     throw {
-      message: `Failed running search for ${item.type} (${item.key}) at ${name}: ${_.getOr(error, 'message', error)}`,
-      error
+      message: `Failed running search for ${item.type} (${
+        item.key
+      }) at ${name}: ${_.getOr(error, 'message', error)}`,
+      error,
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,7 +73,7 @@ let runTypeFunction = config => async (name, item, search) => {
   } catch (error) {
     throw {
       message: `Failed running search for ${item.type} (${item.key}) at ${name}: ${_.getOr(error, 'message', error)}`,
-      F.extendOn(error, { node: item })
+      error: F.extendOn(error, { node: item })
     }
   }
 }


### PR DESCRIPTION
Throws now an error object with the actual error as part of it. This is needed for other repos to know the error details.