### PR TITLE
MemoryProvider: Add `totalRecords` to `results` example type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.5.0
+Memory Provider: Add `totalRecords` to `results` example type
+
 ### 0.4.2
 * Throw Error object instead of just the error message
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {

--- a/src/provider-memory/exampleTypes.js
+++ b/src/provider-memory/exampleTypes.js
@@ -105,6 +105,7 @@ module.exports = () => ({
       { pageSize = 10, page = 1, sortField, sortDir = 'desc' },
       search
     ) => ({
+      totalRecords: search(_.size),
       results: search(
         _.flow(
           _.orderBy(sortField, sortDir),

--- a/test/memory.js
+++ b/test/memory.js
@@ -122,6 +122,7 @@ describe('Memory Provider', () => {
       })
       expect(result.children[2].context).to.deep.equal({
         results: [{ a: 1, b: 1 }, { a: 1, b: 3 }],
+        totalRecords: 2
       })
     })
     it('should handle basic OR test case', async () => {
@@ -163,6 +164,7 @@ describe('Memory Provider', () => {
       })
       expect(result.children[2].context).to.deep.equal({
         results: [{ a: 1, b: 1 }, { a: 1, b: 3 }, { a: 2, b: 2 }],
+        totalRecords: 3
       })
     })
     it('should handle savedSearch', async () => {
@@ -206,6 +208,7 @@ describe('Memory Provider', () => {
       let result = await process(dsl)
       expect(result.children[1].context).to.deep.equal({
         results: [{ a: 1, b: 1 }, { a: 1, b: 3 }],
+        totalRecords: 2,
       })
     })
     it('should handle subquery', async () => {
@@ -254,6 +257,7 @@ describe('Memory Provider', () => {
       let result = await process(dsl)
       expect(result.children[1].context).to.deep.equal({
         results: [{ b: 1, c: 1 }, { b: 3, c: 1 }],
+        totalRecords: 2,
       })
     })
   })

--- a/test/memory.js
+++ b/test/memory.js
@@ -122,7 +122,7 @@ describe('Memory Provider', () => {
       })
       expect(result.children[2].context).to.deep.equal({
         results: [{ a: 1, b: 1 }, { a: 1, b: 3 }],
-        totalRecords: 2
+        totalRecords: 2,
       })
     })
     it('should handle basic OR test case', async () => {
@@ -164,7 +164,7 @@ describe('Memory Provider', () => {
       })
       expect(result.children[2].context).to.deep.equal({
         results: [{ a: 1, b: 1 }, { a: 1, b: 3 }, { a: 2, b: 2 }],
-        totalRecords: 3
+        totalRecords: 3,
       })
     })
     it('should handle savedSearch', async () => {


### PR DESCRIPTION
MemoryProvider: Add `totalRecords` to `results` example type