### PR TITLE
Raw type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.6.0
+* Chore: move from `futil-js` to `futil`
+
 ### 0.5.2
 * Memory Provider: Fix bug in results type pagination
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 0.6.0
+* Add global `raw` example type
 * Chore: move from `futil-js` to `futil`
 
 ### 0.5.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/smartprocure/contexture#readme",
   "dependencies": {
     "bluebird": "^3.5.0",
-    "futil-js": "^1.31.0",
+    "futil": "^1.65.0",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -1,7 +1,7 @@
 // TODO: All of this should move to contexture-export
 
 let _ = require('lodash/fp')
-let F = require('futil-js')
+let F = require('futil')
 
 let safeWalk = _.curry((Tree, f, tree) => {
   let result = _.cloneDeep(tree)

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -1,3 +1,4 @@
+let _ = require('lodash/fp')
 let strategies = require('./dataStrategies')
 
 module.exports = ({ getSavedSearch } = {}) => ({
@@ -36,4 +37,10 @@ module.exports = ({ getSavedSearch } = {}) => ({
       )
     },
   },
+  raw: {
+    hasValue: _.get('filter'),
+    filter: ({ filter }) => filter,
+    validContext: _.get('result'),
+    result: async ({ result }, search) => ({ result: search(result) }),
+  }  
 })

--- a/src/exampleTypes.js
+++ b/src/exampleTypes.js
@@ -42,5 +42,5 @@ module.exports = ({ getSavedSearch } = {}) => ({
     filter: ({ filter }) => filter,
     validContext: _.get('result'),
     result: async ({ result }, search) => ({ result: search(result) }),
-  }  
+  },
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-let F = require('futil-js')
+let F = require('futil')
 let _ = require('lodash/fp')
 let Promise = require('bluebird')
 let utils = require('./utils')

--- a/src/provider-memory/exampleTypes.js
+++ b/src/provider-memory/exampleTypes.js
@@ -1,5 +1,5 @@
 let _ = require('lodash/fp')
-let F = require('futil-js')
+let F = require('futil')
 
 // like `_.includes` but casts everything to string first
 let toStringIncludes = _.curry((item, list) =>

--- a/src/provider-memory/index.js
+++ b/src/provider-memory/index.js
@@ -1,5 +1,5 @@
 let _ = require('lodash/fp')
-let F = require('futil-js')
+let F = require('futil')
 
 let MemoryProvider = {
   groupCombinator: (group, filters) =>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 let _ = require('lodash/fp')
 let Promise = require('bluebird')
-let F = require('futil-js')
+let F = require('futil')
 
 // Parent first promise DFS
 // TODO: futil walkAsync

--- a/test/memory.js
+++ b/test/memory.js
@@ -539,7 +539,7 @@ describe('Memory Provider', () => {
         schema: 'movies',
         type: 'raw',
         filter: x => x.year > 2010,
-        result: _.flow(_.map('year'), _.uniq)
+        result: _.flow(_.map('year'), _.uniq),
       }
       let result = await process(dsl)
       expect(result.context.result).to.deep.equal([2011, 2012, 2013])

--- a/test/memory.js
+++ b/test/memory.js
@@ -533,5 +533,16 @@ describe('Memory Provider', () => {
         'Game of Thrones',
       ])
     })
+    it('should handle raw', async () => {
+      let dsl = {
+        key: 'raw',
+        schema: 'movies',
+        type: 'raw',
+        filter: x => x.year > 2010,
+        result: _.flow(_.map('year'), _.uniq)
+      }
+      let result = await process(dsl)
+      expect(result.context.result).to.deep.equal([2011, 2012, 2013])
+    })
   })
 })


### PR DESCRIPTION
Summary
----
This was a proposed hackathon topic, originally planned just for `contexture-mongo` but generalized to work with any provider. If there's ever a node that doesn't quite do what you need, you can use `raw` to just pass a native filter/result thing.

With `contexture-mongo`, you might use it like this:
```js
{
  key: 'customReport',
  type: 'raw',
  result: fancyOneOffCustomAggregationPipelineArray
}
```

**Alternatively, we might want to call this `native`**


Changes
------
* Add global `raw` example type
* Chore: move from `futil-js` to `futil`