### PR TITLE
On result handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.7.0
+* Pass the node and path in `onResult`, not the raw context value
+* Optimize performance by reducing the number of tree traversals
+* Clean up repo by using new `futil` methods instead of local utils
+* General refactoring
+
 ### 0.6.1
 * Fix `raw` function
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/smartprocure/contexture#readme",
   "dependencies": {
-    "bluebird": "^3.7.2",
     "futil": "^1.66.1",
     "lodash": "^4.17.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/smartprocure/contexture#readme",
   "dependencies": {
-    "bluebird": "^3.5.0",
-    "futil": "^1.65.0",
+    "bluebird": "^3.7.2",
+    "futil": "^1.66.1",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -3,14 +3,8 @@
 let _ = require('lodash/fp')
 let F = require('futil')
 
-let safeWalk = _.curry((Tree, f, tree) => {
-  let result = _.cloneDeep(tree)
-  Tree.walk(f)(result)
-  return result
-})
-
 let Tree = F.tree(_.get('children'), key => ({ key }))
-let setFilterOnly = safeWalk(Tree, node => {
+let setFilterOnly = Tree.transform(node => {
   node.filterOnly = true
 })
 let lastChild = x => _.last(Tree.traverse(x))

--- a/src/index.js
+++ b/src/index.js
@@ -67,9 +67,7 @@ let process = _.curry(async ({ providers, schemas }, group, options = {}) => {
 
     return group
   } catch (error) {
-    throw error.node
-      ? error
-      : new Error(`Failed running search (uncaught): ${error}`)
+    throw error.node ? error : new Error(`Uncaught search exception: ${error}`)
   }
 })
 module.exports = process

--- a/src/index.js
+++ b/src/index.js
@@ -29,15 +29,13 @@ let process = _.curryN(
     })
     let group = _.cloneDeep(groupParam)
     try {
-      await Tree.walkAsync(
-        async (node, ...args) => {
-          initNode(node, ...args)
-          node._meta.hasValue = await runTypeFunction('hasValue', node)
-          if (node._meta.hasValue && !node.contextOnly) {
-            node._meta.filter = await runTypeFunction('filter', node)
-          }
+      await Tree.walkAsync(async (node, ...args) => {
+        initNode(node, ...args)
+        node._meta.hasValue = await runTypeFunction('hasValue', node)
+        if (node._meta.hasValue && !node.contextOnly) {
+          node._meta.filter = await runTypeFunction('filter', node)
         }
-      )(group)
+      })(group)
       Tree.walk(node => {
         // Skip groups
         if (!getChildren(node))

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ let process = _.curry(async ({ providers, schemas }, group, options = {}) => {
     options,
     getSchema,
     getProvider,
-    processGroup: (g, options) => process({ providers, schemas }, g, options)
+    processGroup: (g, options) => process({ providers, schemas }, g, options),
   })
   try {
     await Tree.walkAsync(async (node, ...args) => {

--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,9 @@ let process = _.curryN(
           }
         )
         node.context = result
+        let path = node._meta.path
         if (!options.debug) delete node._meta
-        if (options.onResult) options.onResult(result)
+        if (options.onResult) options.onResult({ path, node })
       })
       
       return group

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ let Tree = F.tree(getChildren)
 let initNode = (node, i, [{ schema, _meta: { path = [] } = {} } = {}]) => {
   // Add schema, _meta path and requests
   F.defaultsOn(
-    { _meta: { requests: [], path: path.concat([node.key]) }, schema },
+    { schema, _meta: { requests: [], path: path.concat([node.key]) } },
     node
   )
   // Flatten legacy fields

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,7 @@ let _ = require('lodash/fp')
 let utils = require('./utils')
 
 let extendAllOn = _.extendAll.convert({ immutable: false })
-let { getChildren, getRelevantFilters } = utils
-let Tree = F.tree(getChildren)
+let { Tree, getRelevantFilters } = utils
 
 let initNode = (node, i, [{ schema, _meta: { path = [] } = {} } = {}]) => {
   // Add schema, _meta path and requests
@@ -35,7 +34,7 @@ let process = _.curry(async ({ providers, schemas }, group, options = {}) => {
     })(group)
     Tree.walk(node => {
       // Skip groups
-      if (!getChildren(node))
+      if (!Tree.traverse(node))
         node._meta.relevantFilters = getRelevantFilters(
           getProvider(node).groupCombinator,
           node._meta.path,

--- a/src/index.js
+++ b/src/index.js
@@ -16,67 +16,63 @@ let initNode = (node, i, [{ schema, _meta: { path = [] } = {} } = {}]) => {
   extendAllOn([node, node.config, node.data])
 }
 
-let process = _.curryN(
-  2,
-  async ({ providers, schemas }, groupParam, options = {}) => {
-    let getProvider = utils.getProvider(providers, schemas)
-    let getSchema = schema => schemas[schema]
-    let runTypeFunction = utils.runTypeFunction({
-      options,
-      getSchema,
-      getProvider,
-      processGroup: (g, options) => process({ providers, schemas }, g, options),
-    })
-    let group = _.cloneDeep(groupParam)
-    try {
-      await Tree.walkAsync(async (node, ...args) => {
-        initNode(node, ...args)
-        node._meta.hasValue = await runTypeFunction('hasValue', node)
-        if (node._meta.hasValue && !node.contextOnly) {
-          node._meta.filter = await runTypeFunction('filter', node)
-        }
-      })(group)
-      Tree.walk(node => {
-        // Skip groups
-        if (!getChildren(node))
-          node._meta.relevantFilters = getRelevantFilters(
-            getProvider(node).groupCombinator,
-            node._meta.path,
-            group
-          )
-      })(group)
-      await Tree.walkAsync(async node => {
-        let validContext = await runTypeFunction('validContext', node)
-
-        // Reject filterOnly
-        if (node.filterOnly || !validContext) return
-
-        let curriedSearch = _.partial(getProvider(node).runSearch, [
-          options,
-          node,
-          getSchema(node.schema),
-          node._meta.relevantFilters,
-        ])
-
-        let result = await runTypeFunction('result', node, curriedSearch).catch(
-          error => {
-            throw F.extendOn(error, { node })
-          }
+let process = _.curry(async ({ providers, schemas }, group, options = {}) => {
+  let getProvider = utils.getProvider(providers, schemas)
+  let getSchema = schema => schemas[schema]
+  let runTypeFunction = utils.runTypeFunction({
+    options,
+    getSchema,
+    getProvider,
+    processGroup: (g, options) => process({ providers, schemas }, g, options),
+  })
+  try {
+    await Tree.walkAsync(async (node, ...args) => {
+      initNode(node, ...args)
+      node._meta.hasValue = await runTypeFunction('hasValue', node)
+      if (node._meta.hasValue && !node.contextOnly) {
+        node._meta.filter = await runTypeFunction('filter', node)
+      }
+    })(group)
+    Tree.walk(node => {
+      // Skip groups
+      if (!getChildren(node))
+        node._meta.relevantFilters = getRelevantFilters(
+          getProvider(node).groupCombinator,
+          node._meta.path,
+          group
         )
-        node.context = result
-        let path = node._meta.path
-        if (!options.debug) delete node._meta
-        if (options.onResult) options.onResult({ path, node })
-      })(group)
+    })(group)
+    await Tree.walkAsync(async node => {
+      let validContext = await runTypeFunction('validContext', node)
 
-      return group
-    } catch (error) {
-      throw error.node
-        ? error
-        : new Error(`Failed running search (uncaught): ${error}`)
-    }
+      // Reject filterOnly
+      if (node.filterOnly || !validContext) return
+
+      let curriedSearch = _.partial(getProvider(node).runSearch, [
+        options,
+        node,
+        getSchema(node.schema),
+        node._meta.relevantFilters,
+      ])
+
+      let result = await runTypeFunction('result', node, curriedSearch).catch(
+        error => {
+          throw F.extendOn(error, { node })
+        }
+      )
+      node.context = result
+      let path = node._meta.path
+      if (!options.debug) delete node._meta
+      if (options.onResult) options.onResult({ path, node })
+    })(group)
+
+    return group
+  } catch (error) {
+    throw error.node
+      ? error
+      : new Error(`Failed running search (uncaught): ${error}`)
   }
-)
+})
 module.exports = process
 
 // Psuedo code process

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ let process = _.curry(async ({ providers, schemas }, group, options = {}) => {
     options,
     getSchema,
     getProvider,
-    processGroup: (g, options) => process({ providers, schemas }, g, options),
+    processGroup: (g, options) => process({ providers, schemas }, g, options)
   })
   try {
     await Tree.walkAsync(async (node, ...args) => {
@@ -54,12 +54,11 @@ let process = _.curry(async ({ providers, schemas }, group, options = {}) => {
         node._meta.relevantFilters,
       ])
 
-      let result = await runTypeFunction('result', node, curriedSearch).catch(
+      node.context = await runTypeFunction('result', node, curriedSearch).catch(
         error => {
           throw F.extendOn(error, { node })
         }
       )
-      node.context = result
       let path = node._meta.path
       if (!options.debug) delete node._meta
       if (options.onResult) options.onResult({ path, node })

--- a/src/index.js
+++ b/src/index.js
@@ -29,9 +29,9 @@ let process = _.curryN(
     })
     let group = _.cloneDeep(groupParam)
     try {
-      Tree.walk(initNode)(group)
       await Tree.walkAsync(
-        async node => {
+        async (node, ...args) => {
+          initNode(node, ...args)
           node._meta.hasValue = await runTypeFunction('hasValue', node)
           if (node._meta.hasValue && !node.contextOnly) {
             node._meta.filter = await runTypeFunction('filter', node)

--- a/src/index.js
+++ b/src/index.js
@@ -72,10 +72,8 @@ let process = _.curryN(
           }
         )
         node.context = result
+        if (!options.debug) delete node._meta
         if (options.onResult) options.onResult(result)
-      })
-      await walk(item => {
-        if (!options.debug) delete item._meta
       })
       
       return group

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ let process = _.curryN(
         if (!options.debug) delete node._meta
         if (options.onResult) options.onResult({ path, node })
       })(group)
-      
+
       return group
     } catch (error) {
       throw error.node

--- a/src/provider-debug/index.js
+++ b/src/provider-debug/index.js
@@ -1,5 +1,3 @@
-let Promise = require('bluebird')
-
 let DebugProvider = {
   groupCombinator: (group, filters) => ({
     [group.join]: filters,
@@ -17,15 +15,15 @@ let DebugProvider = {
     test: {
       filter: x => ({ [`${x.field || x.key} (${x.type})`]: x.data }),
       result: (context, search) =>
-        search({ test: context.config }).return({
+        search({ test: context.config }).then(() => ({
           abc: 123,
-        }),
+        })),
     },
     results: {
       result: (context, search) =>
-        search({ results: context.config }).return({
+        search({ results: context.config }).then(() => ({
           results: [],
-        }),
+        })),
     },
   },
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,7 +14,7 @@ let getProvider = _.curry(
     )
 )
 
-let getChildren = F.cascade(['children', 'items', 'data.items'])
+let getChildren = x => F.cascade(['children', 'items', 'data.items'], x)
 let getRelevantFilters = _.curry((groupCombinator, Path, group) => {
   if (!_.includes(group.key, Path))
     // If we're not in the path, it doesn't matter what the rest of it is

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,15 +1,5 @@
 let _ = require('lodash/fp')
-let Promise = require('bluebird')
 let F = require('futil')
-
-// Parent first promise DFS
-// TODO: futil walkAsync
-let parentFirstDFS = async (getChildren, fn, collection, parent) => {
-  await fn(collection, parent)
-  await Promise.map(getChildren(collection) || [], item =>
-    parentFirstDFS(getChildren, fn, item, collection)
-  )
-}
 
 // TODO: Handle no provider and have global default?
 let getProvider = _.curry(
@@ -78,7 +68,6 @@ let runTypeFunction = config => async (name, item, search) => {
 }
 
 module.exports = {
-  parentFirstDFS,
   getProvider,
   getChildren,
   getRelevantFilters,

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,7 +62,7 @@ let runTypeFunction = config => async (name, node, search) => {
         node.key
       }) at ${name}: ${_.getOr(error, 'message', error)}`,
       error,
-      node: node,
+      node,
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,13 +3,13 @@ let F = require('futil')
 
 // TODO: Handle no provider and have global default?
 let getProvider = _.curry(
-  (providers, schemas, item) =>
+  (providers, schemas, node) =>
     providers[
-      item.provider || F.firstCommonKey(providers, schemas[item.schema])
+      node.provider || F.firstCommonKey(providers, schemas[node.schema])
     ] ||
     F.throws(
       new Error(
-        `No Provider found ${item.schema} and was not overridden for ${item.key}`
+        `No Provider found ${node.schema} and was not overridden for ${node.key}`
       )
     )
 )
@@ -31,7 +31,7 @@ let getRelevantFilters = _.curry((groupCombinator, Path, group) => {
     relevantChildren = _.filter({ key: currentKey }, relevantChildren)
   // Exclude self
   relevantChildren = _.reject(
-    item => item.key === currentKey && !getChildren(item),
+    node => node.key === currentKey && !getChildren(node),
     relevantChildren
   )
 
@@ -45,24 +45,24 @@ let getRelevantFilters = _.curry((groupCombinator, Path, group) => {
   return groupCombinator(group, _.compact(relevantFilters))
 })
 
-let runTypeFunction = config => async (name, item, search) => {
-  let schema = config.getSchema(item.schema)
+let runTypeFunction = config => async (name, node, search) => {
+  let schema = config.getSchema(node.schema)
   let fn = F.cascade(
-    [`${item.type}.${name}`, `default.${name}`],
-    config.getProvider(item).types,
+    [`${node.type}.${name}`, `default.${name}`],
+    config.getProvider(node).types,
     _.noop
   )
   try {
     return await (search
-      ? fn(item, search, schema, config)
-      : fn(item, schema, config))
+      ? fn(node, search, schema, config)
+      : fn(node, schema, config))
   } catch (error) {
     throw {
-      message: `Failed running search for ${item.type} (${
-        item.key
+      message: `Failed running search for ${node.type} (${
+        node.key
       }) at ${name}: ${_.getOr(error, 'message', error)}`,
       error,
-      node: item,
+      node: node,
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,15 +11,11 @@ let parentFirstDFS = async (getChildren, fn, collection, parent) => {
   )
 }
 
-// For futil? map args is _.overArgs on all args
-let mapArgs = (f, g) => (...x) => f(...x.map(g))
-let commonKeys = mapArgs(_.intersection, _.keys)
-
 // TODO: Handle no provider and have global default?
 let getProvider = _.curry(
   (providers, schemas, item) =>
     providers[
-      item.provider || _.first(commonKeys(providers, schemas[item.schema]))
+      item.provider || F.firstCommonKey(providers, schemas[item.schema])
     ] ||
     F.throws(
       new Error(

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,20 +1,9 @@
 let _ = require('lodash/fp')
 let F = require('futil')
 
-// TODO: Handle no provider and have global default?
-let getProvider = _.curry(
-  (providers, schemas, node) =>
-    providers[
-      node.provider || F.firstCommonKey(providers, schemas[node.schema])
-    ] ||
-    F.throws(
-      new Error(
-        `No Provider found ${node.schema} and was not overridden for ${node.key}`
-      )
-    )
-)
-
 let getChildren = x => F.cascade(['children', 'items', 'data.items'], x)
+let Tree = F.tree(getChildren)
+
 let getRelevantFilters = _.curry((groupCombinator, Path, group) => {
   if (!_.includes(group.key, Path))
     // If we're not in the path, it doesn't matter what the rest of it is
@@ -45,6 +34,18 @@ let getRelevantFilters = _.curry((groupCombinator, Path, group) => {
   return groupCombinator(group, _.compact(relevantFilters))
 })
 
+let getProvider = _.curry(
+  (providers, schemas, node) =>
+    providers[
+      node.provider || F.firstCommonKey(providers, schemas[node.schema])
+    ] ||
+    F.throws(
+      new Error(
+        `No Provider found ${node.schema} and was not overridden for ${node.key}`
+      )
+    )
+)
+
 let runTypeFunction = config => async (name, node, search) => {
   let schema = config.getSchema(node.schema)
   let fn = F.cascade(
@@ -68,8 +69,8 @@ let runTypeFunction = config => async (name, node, search) => {
 }
 
 module.exports = {
-  getProvider,
-  getChildren,
+  Tree,
   getRelevantFilters,
+  getProvider,
   runTypeFunction,
 }

--- a/test/memory.js
+++ b/test/memory.js
@@ -544,5 +544,32 @@ describe('Memory Provider', () => {
       let result = await process(dsl)
       expect(result.context.result).to.deep.equal([2011, 2012, 2013])
     })
+    it('should handle onResult', async () => {
+      let dsl = {
+        key: 'root',
+        type: 'group',
+        schema: 'movies',
+        join: 'and',
+        children: [
+          {
+            key: 'ratings',
+            type: 'facet',
+            field: 'rated',
+            values: ['R', 'PG-13'],
+          },
+          {
+            key: 'results',
+            type: 'results',
+            page: 1,
+          },
+        ],
+      }
+      let results = []
+      let onResult = x => {
+        results.push(x)
+      }
+      await process(dsl, { onResult })
+      expect(_.map('path', results)).to.deep.equal([['root'], ['root', 'ratings'], ['root', 'results']])
+    })
   })
 })

--- a/test/memory.js
+++ b/test/memory.js
@@ -569,7 +569,11 @@ describe('Memory Provider', () => {
         results.push(x)
       }
       await process(dsl, { onResult })
-      expect(_.map('path', results)).to.deep.equal([['root'], ['root', 'ratings'], ['root', 'results']])
+      expect(_.map('path', results)).to.deep.equal([
+        ['root'],
+        ['root', 'ratings'],
+        ['root', 'results'],
+      ])
     })
   })
 })


### PR DESCRIPTION
* Pass the node and path in `onResult`, not the raw context value
* Optimize performance by reducing the number of tree traversals
* Clean up repo by using new `futil` methods instead of local utils
* General refactoring