### PR TITLE
Fix "Desccription" typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.7.1
+* Fix "Desccription" typo to "Description"
+
 ### 0.7.0
 * Pass the node and path in `onResult`, not the raw context value
 * Optimize performance by reducing the number of tree traversals

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ While the Contexture DSL can be built anyway you'd like, it pairs well with the 
 
 ### Ecosystem And Resources
 
-| Github | npm | Desccription |
+| Github | npm | Description |
 | ------ | --- | ------------ |
 | [`contexture`](http://github.com/smartprocure/contexture) | [`contexture`](https://www.npmjs.com/package/contexture) | The core library that exectues the DSL to retrieve data |
 | [`contexture-elasticsearch`](http://github.com/smartprocure/contexture-elasticsearch) | [`contexture-elasticsearch`](https://www.npmjs.com/package/contexture-elasticsearch) | Elasticsearch provider for contexture |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes a small typo that says "Desccription" instead of intended "Description". 

-------------

Related to the "Ecosystem and Resources" section of the README here, I created a `awesome-contexture`. 

This list includes the best applications, libraries, documentation, and other resources from the Contexture ecosystem. It is a great way for the community to see the best of Contexture in one place and to be able to contribute to the growing ecosystem

- Awesome Contexture: https://github.com/ltchris/awesome-contexture
- PR to the official awesome repo (128k+ stars, [number 8 top-stared repo in all of GitHub](https://github.com/search?q=stars%3A%3E100&s=stars&type=Repositories)): https://github.com/sindresorhus/awesome/pull/1727
  - Was merged to official repo: https://github.com/sindresorhus/awesome#databases
  - https://twitter.com/awesome__re/status/1237011247087808512