### PR TITLE
Allow passing up schemas from the client

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ let initNode = (node, i, [{ schema, _meta: { path = [] } = {} } = {}]) => {
 
 let process = _.curry(async ({ providers, schemas }, group, options = {}) => {
   let getProvider = utils.getProvider(providers, schemas)
-  let getSchema = schema => schemas[schema]
+  let getSchema = F.when(_.isString, _.get(_, schemas))  
   let runTypeFunction = utils.runTypeFunction({
     options,
     getSchema,

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ let initNode = (node, i, [{ schema, _meta: { path = [] } = {} } = {}]) => {
 
 let process = _.curry(async ({ providers, schemas }, group, options = {}) => {
   let getProvider = utils.getProvider(providers, schemas)
-  let getSchema = F.when(_.isString, _.get(_, schemas))  
+  let getSchema = F.when(_.isString, _.get(_, schemas))
   let runTypeFunction = utils.runTypeFunction({
     options,
     getSchema,


### PR DESCRIPTION
This allows schemas to be objects instead of strings, which replace the entire schema lookup. It would allow you to do something like this:

```js
let tree = {
  key: 'root',
  schema: {
    mongo: {
      collection: 'quoteRequests',
      $lookup: { /*...*/ }, // when/if supported
    },
  },
  children: [
    {
      key: 'criteria',
      children: [],
    },
    { /*...*/ },
  ],
}

```

Instead of this, we might just want the contexture core to support passing in a `getSchema` function instead of an object map of schemas.