### PR TITLE
Handle memory facet dotted paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.9.1
+* Memory facet type: handle dotted paths
+
 ### 0.9.0
 * Memory facet type
     * Unwind results

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {

--- a/src/provider-memory/exampleTypes.js
+++ b/src/provider-memory/exampleTypes.js
@@ -78,13 +78,12 @@ module.exports = () => ({
   facet: {
     hasValue: node => _.size(node.values),
     filter: ({ field, values }) =>
-      _.conforms({
-        [field]: _.flow(
-          _.castArray,
-          _.intersectionWith(_.isEqual, values),
-          _.negate(_.isEmpty)
-        ),
-      }),
+      _.flow(
+        _.get(field),
+        _.castArray,
+        _.intersectionWith(_.isEqual, values),
+        _.negate(_.isEmpty)
+      ),
     result({ field, size = 10, optionsFilter }, search) {
       let options = search(
         _.flow(


### PR DESCRIPTION
Filtering a dotted path field would not work since _.conforms doesn't respect dotted paths