### PR TITLE
feature/51 - factor out attachFilters util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 0.10.1 
+### 0.11.0 
 * export fn to attach _meta.filters to search nodes
 
 ### 0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.9.5 
+* export fn to attach _meta.filters to search nodes
+
 ### 0.9.4
 * Fix memory date type and add tests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -94,6 +94,5 @@ module.exports = {
   getRelevantFilters,
   getProvider,
   runTypeFunction,
-  initNode,
   attachFilters,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,13 +80,14 @@ let initNode = (node, i, [{ schema, _meta: { path = [] } = {} } = {}]) => {
   extendAllOn([node, node.config, node.data])
 }
 
-let attachFilters = runTypeFunction => async group => Tree.walkAsync(async (node, ...args) => {
-  initNode(node, ...args)
-  node._meta.hasValue = await runTypeFunction('hasValue', node)
-  if (node._meta.hasValue && !node.contextOnly) {
-    node._meta.filter = await runTypeFunction('filter', node)
-  }
-})(group)
+let attachFilters = runTypeFunction => async group =>
+  Tree.walkAsync(async (node, ...args) => {
+    initNode(node, ...args)
+    node._meta.hasValue = await runTypeFunction('hasValue', node)
+    if (node._meta.hasValue && !node.contextOnly) {
+      node._meta.filter = await runTypeFunction('filter', node)
+    }
+  })(group)
 
 module.exports = {
   Tree,
@@ -94,5 +95,5 @@ module.exports = {
   getProvider,
   runTypeFunction,
   initNode,
-  attachFilters
+  attachFilters,
 }


### PR DESCRIPTION
Fixes #51 

### Description
* factors out and exports the fn that attaches provider-constructed `_meta.filter` to the nodes in the search
* use case: custom node types need to be able to load a contexture blob and transform it into provider-appropriate filters in order to build filters that work by projecting contexture data (e.g. saved searches)