### PR TITLE
fix the unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.11.1 
+* fix unit test of date type 
+
 ### 0.11.0 
 * export fn to attach _meta.filters to search nodes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ### 0.11.1 
-* fix unit test of date type 
+* Fix unit test of date type 
 
 ### 0.11.0 
-* export fn to attach _meta.filters to search nodes
+* Export fn to attach _meta.filters to search nodes
 
 ### 0.10.0
-* add next18Months rolling memory date type option
+* Add next18Months rolling memory date type option
 
 ### 0.9.4
 * Fix memory date type and add tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 0.11.1 
-* Fix unit test of date type 
+* Fix unit test:  Date example type test cases - lastCalendarMonth 
 
 ### 0.11.0 
 * Export fn to attach _meta.filters to search nodes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {

--- a/test/date.js
+++ b/test/date.js
@@ -172,7 +172,10 @@ describe('Date example type test cases', () => {
       ],
     }))
   it('lastCalendarMonth', async () =>
-    testRange({ range: 'lastCalendarMonth', expected: ['lastMonth','last3Days','last6Days','last20Days'] }))
+    testRange({
+      range: 'lastCalendarMonth',
+      expected: ['lastMonth', 'last3Days', 'last6Days', 'last20Days'],
+    }))
   it('next6Months', async () =>
     testRange({ range: 'next6Months', expected: ['tomorrow', 'nextMonth'] }))
   it('next36Months', async () =>

--- a/test/date.js
+++ b/test/date.js
@@ -172,7 +172,7 @@ describe('Date example type test cases', () => {
       ],
     }))
   it('lastCalendarMonth', async () =>
-    testRange({ range: 'lastCalendarMonth', expected: ['lastMonth'] }))
+    testRange({ range: 'lastCalendarMonth', expected: ['lastMonth','last3Days','last6Days','last20Days'] }))
   it('next6Months', async () =>
     testRange({ range: 'next6Months', expected: ['tomorrow', 'nextMonth'] }))
   it('next36Months', async () =>


### PR DESCRIPTION
Fixed the fail of the unit test `Date example type test cases- lastCalendarMonth` 

Double checked the code https://github.com/smartprocure/contexture/blob/master/src/provider-memory/date.js#L115.
we should return all 4 options which are less than a month. they are ['lastMonth', 'last3Days', 'last6Days', 'last20Days']

The unit test has been corrected.
![image](https://user-images.githubusercontent.com/10645051/100822725-e295d480-3420-11eb-9a7e-c2226bdac4a3.png)


![image](https://user-images.githubusercontent.com/10645051/100821997-78306480-341f-11eb-8639-008ae589ef96.png)
