### PR TITLE
Changed the way error are handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.11.1
+* Adjusts the way errors are handled so they can be handled on a per node basis
+
 ### 0.11.1 
 * Fix unit test:  Date example type test cases - lastCalendarMonth 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,13 +58,7 @@ let runTypeFunction = config => async (name, node, search) => {
       ? fn(node, search, schema, config)
       : fn(node, schema, config))
   } catch (error) {
-    throw {
-      message: `Failed running search for ${node.type} (${
-        node.key
-      }) at ${name}: ${_.getOr(error, 'message', error)}`,
-      error,
-      node,
-    }
+    return error
   }
 }
 


### PR DESCRIPTION
Return the raw error so errors can be handled on a per node basis

related https://github.com/smartprocure/contexture-elasticsearch/pull/167