### PR TITLE
Revert "Fix/performance"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### 0.12.4
 * Revert parallelization until we can make it configurable and test more thoroughly
+### 0.12.3
+* Converted tests to jest
+
+### 0.12.2
+* Updated CI to use node16 and npm7
+* Updated package-lock.json to version 2
 
 ### 0.12.1
 * Performance: executing runSearch requests in parallel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
-### 0.12.1
-* Performance: executing runSearch requests in parallel
-
 ### 0.12.0
 * Add last 1 Day and last 1 hour to date math calculations
-
 ### 0.11.3
 * Changed over CI from circleCI to Github Actions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### 0.12.1
 * Performance: executing runSearch requests in parallel
- 
+
 ### 0.12.0
 * Add last 1 Day and last 1 hour to date math calculations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
+### 0.12.2
+* Revert parallelization until we can make it configurable and test more thoroughly
+
+### 0.12.1
+* Performance: executing runSearch requests in parallel
+ 
 ### 0.12.0
 * Add last 1 Day and last 1 hour to date math calculations
+
 ### 0.11.3
 * Changed over CI from circleCI to Github Actions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.12.1",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.12.1",
+  "version": "0.12.0",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -23,32 +23,28 @@ let process = _.curry(async ({ providers, schemas }, group, options = {}) => {
           group
         )
     })(group)
-    await Promise.all(
-      Tree.toArrayBy(async node => {
-        let validContext = await runTypeFunction('validContext', node)
+    await Tree.walkAsync(async node => {
+      let validContext = await runTypeFunction('validContext', node)
 
-        // Reject filterOnly
-        if (node.filterOnly || !validContext) return
+      // Reject filterOnly
+      if (node.filterOnly || !validContext) return
 
-        let curriedSearch = _.partial(getProvider(node).runSearch, [
-          options,
-          node,
-          getSchema(node.schema),
-          node._meta.relevantFilters,
-        ])
+      let curriedSearch = _.partial(getProvider(node).runSearch, [
+        options,
+        node,
+        getSchema(node.schema),
+        node._meta.relevantFilters,
+      ])
 
-        node.context = await runTypeFunction(
-          'result',
-          node,
-          curriedSearch
-        ).catch(error => {
+      node.context = await runTypeFunction('result', node, curriedSearch).catch(
+        error => {
           throw F.extendOn(error, { node })
-        })
-        let path = node._meta.path
-        if (!options.debug) delete node._meta
-        if (options.onResult) options.onResult({ path, node })
-      })(group)
-    )
+        }
+      )
+      let path = node._meta.path
+      if (!options.debug) delete node._meta
+      if (options.onResult) options.onResult({ path, node })
+    })(group)
 
     return group
   } catch (error) {


### PR DESCRIPTION
Reverts smartprocure/contexture#63

Running all searches in parallel is not necessarily a good thing - and in fact, on an elastic cluster with a maximum number of parallel queries, can be actively harmful for overall availability and stability of the cluster. Coupled with the multisearch PR for contexture-elasticsearch, this might be a good thing - but we need to do extensive testing and likely allow a way to switch between parallel and serial on a per provider, schema, and maybe even per tree basis.