### PR TITLE
Fix package publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.12.10
+
+- Fix package publishing
+
 ### 0.12.9
 
 - Thread search options in example types

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "contexture",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "description": "The Contexture (aka ContextTree) Core",
+  "files": [
+    "./dist"
+  ],
   "main": "dist/index.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Currently the `dist` folder is not being published because it's ignored by git, but that's actually the only folder we want to publish.